### PR TITLE
Fixed type for OTPField default export and added correct package name to README example import

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # react-native-otp-field
 
-### React Native OTP Field 
+### React Native OTP Field
 :one: :two: :three: :four: :five:
 
 ### Installation
@@ -30,7 +30,7 @@ Note: It accepts all other props of RN TextField
 ### Usage:
 
 ```javascript
-import OTPField from 'rn-otp-field';
+import OTPField from 'react-native-otp-field';
 
 render() {
   return {

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ containerStyle | Object | style for text field container.
 error | string | error text to display.
 errorStyle | Object | style for error container.
 
-Note: It accepts all other props of RN TextField
+Note: It accepts all other props of RN TextInput
 
 ### Usage:
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -2,10 +2,11 @@ import * as React from "react";
 import {
   StyleProp,
   TextStyle,
-  ViewStyle
+  ViewStyle,
+  TextInputProps
 } from "react-native";
 
-export interface OTPFieldProps {
+export interface OTPFieldProps extends TextInputProps {
 
   /**
    * Length of the OTP to be captured.

--- a/index.d.ts
+++ b/index.d.ts
@@ -47,4 +47,6 @@ export interface OTPFieldProps {
  * A UI component to take OTP input.
  */
 
-declare interface OTPField extends React.FunctionComponent<OTPFieldProps> { }
+declare const OTPField: React.FunctionComponent<OTPFieldProps>
+
+export default OTPField

--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ import { View, TextInput, StyleSheet, Pressable, Platform, Text } from 'react-na
  * @prop {Object} errorStyle style for error container.
  * other text field props
  */
-const OTPField = ({ length, value, onChange, textFieldStyle, containerStyle, error, errorStyle, ...props }) => {
+const OTPField = ({ length, value, onChange, textFieldStyle, containerStyle, error, errorStyle, autoFocus, ...props }) => {
   const refs = [];
   for (let i = 0; i < length; i++) {
     refs.push(useRef(null));
@@ -74,6 +74,7 @@ const OTPField = ({ length, value, onChange, textFieldStyle, containerStyle, err
                     onChangeText={(value) => onChangeText(value, index)}
                     onSubmitEditing={() => { }}
                     keyboardType={'number-pad'}
+                    autoFocus={autoFocus && index === 0 ? true : false}
                     {...props}
                   />
                 </View>


### PR DESCRIPTION
I upgraded to 0.0.11 and found there were still some odd typescript errors.

Finally, I realized index.d.ts is exporting OTPField as an interface, not as an actual component, so I changed that.

Also realized the example in README.md has the wrong package name in the import line, so I changed that too